### PR TITLE
Revert "Tidyselect update"

### DIFF
--- a/R/categorical.R
+++ b/R/categorical.R
@@ -22,17 +22,17 @@ tab_frequencies <- function(data, ...) {
     dplyr::group_by(..., !!!grouping) %>%
     dplyr::summarise(n = dplyr::n()) %>%
     dplyr::group_by(!!!grouping) %>%
-    dplyr::mutate(percent = n / sum(n)) %>%
+    dplyr::mutate(percent = .data$n / sum(.data$n)) %>%
     dplyr::arrange(!!!grouping)
 
   d %>%
     dplyr::bind_cols(d %>%
                 dplyr::select(!!!grouping,
-                       cum_n = n,
-                       cum_percent = percent) %>%
+                       cum_n = .data$n,
+                       cum_percent = .data$percent) %>%
                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), cumsum) %>%
                 dplyr::ungroup() %>%
-                dplyr::select(cum_n, cum_percent)
+                dplyr::select(.data$cum_n, .data$cum_percent)
     )
 
 }
@@ -69,21 +69,23 @@ crosstab <- function(data, col_var, ..., add_total = FALSE,
             call. = FALSE)
   }
 
-  if (length(quos(...)) < 1) {
+  cross_vars <- length(quos(...))
+
+  if (cross_vars < 1) {
     stop("Must provide at least one variable to crosstabulate.")
   }
 
   xt <- data %>%
     dplyr::group_by({{ col_var }}, ...) %>%
     dplyr::count() %>%
-    tidyr::spread({{ col_var }}, n, fill = 0) %>%
+    tidyr::spread({{ col_var }}, .data$n, fill = 0) %>%
     dplyr::ungroup()
 
   xt_cross_vars <- xt %>%
-    dplyr::select(...)
+    dplyr::select(c(1:cross_vars))
 
   xt_col_vars <- xt %>%
-    dplyr::select(-c(...))
+    dplyr::select(-c(1:cross_vars))
 
   if (chi_square) {
     chi2 <- xt_col_vars %>%
@@ -98,7 +100,7 @@ crosstab <- function(data, col_var, ..., add_total = FALSE,
 
   if (add_total) {
     xt_col_vars <- xt_col_vars %>%
-      dplyr::mutate(Total = rowSums(.))
+      dplyr::mutate(Total = rowSums(xt_col_vars))
   }
 
   if (percentages) {

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -55,7 +55,7 @@ to_correlation_matrix <- function(data) {
   estimate <- names(data)[3]
 
   var_order <- data %>%
-    dplyr::pull(x) %>%
+    dplyr::pull(.data$x) %>%
     unique()
 
   data %>%
@@ -63,14 +63,12 @@ to_correlation_matrix <- function(data) {
     dplyr::bind_rows(
       data %>%
         dplyr::select(x = 1, y = 2, cor = 3) %>%
-        dplyr::rename(x = y, y = x)
+        dplyr::rename(x = .data$y, y = .data$x)
     ) %>%
-    tidyr::spread(y, cor, fill = 1) %>%
-    dplyr::arrange(match(x, var_order)) %>%
-    dplyr::rename(!!estimate := x) %>%
-    dplyr::select(tidyselect::all_of(estimate),
-                  tidyselect::all_of(var_order),
-                  dplyr::everything())
+    tidyr::spread(.data$y, .data$cor, fill = 1) %>%
+    dplyr::arrange(match(.data$x, var_order)) %>%
+    dplyr::rename(!!estimate := .data$x) %>%
+    dplyr::select(estimate, var_order, dplyr::everything())
 }
 
 ### Internal functions ###

--- a/R/describe.R
+++ b/R/describe.R
@@ -44,24 +44,24 @@ describe <- function(data, ..., na.rm = TRUE) {
   data %>%
     dplyr::select(!!!vars, !!!grouping) %>%
     tidyr::pivot_longer(c(!!!vars), names_to = "Variable", values_to = "Value") %>%
-    dplyr::group_by(Variable, .add = TRUE, .drop = TRUE) %>%
+    dplyr::group_by(.data$Variable, .add = TRUE, .drop = TRUE) %>%
     dplyr::summarise(
-      N = dplyr::n() - sum(is.na(Value)),
-      Missing = sum(is.na(Value)),
-      M = mean(Value, na.rm = na.rm),
-      SD = sd(Value, na.rm = na.rm),
-      Min = min(Value, na.rm = na.rm),
-      Q25 = quantile(Value, .25, na.rm = na.rm),
-      Mdn = median(Value, na.rm = na.rm),
-      Q75 = quantile(Value, .75, na.rm = na.rm),
-      Max = max(Value, na.rm = na.rm),
-      Range = Max - Min,
-      CI_95_LL = M - stats::qt(0.975, df = N-1) * SD/sqrt(N),
-      CI_95_UL = M + stats::qt(0.975, df = N-1) * SD/sqrt(N),
-      Skewness = skewness(Value),
-      Kurtosis = kurtosis(Value)
+      N = dplyr::n() - sum(is.na(.data$Value)),
+      Missing = sum(is.na(.data$Value)),
+      M = mean(.data$Value, na.rm = na.rm),
+      SD = sd(.data$Value, na.rm = na.rm),
+      Min = min(.data$Value, na.rm = na.rm),
+      Q25 = quantile(.data$Value, .25, na.rm = na.rm),
+      Mdn = median(.data$Value, na.rm = na.rm),
+      Q75 = quantile(.data$Value, .75, na.rm = na.rm),
+      Max = max(.data$Value, na.rm = na.rm),
+      Range = .data$Max - .data$Min,
+      CI_95_LL = .data$M - stats::qt(0.975, df = .data$N-1) * .data$SD/sqrt(.data$N),
+      CI_95_UL = .data$M + stats::qt(0.975, df = .data$N-1) * .data$SD/sqrt(.data$N),
+      Skewness = skewness(.data$Value),
+      Kurtosis = kurtosis(.data$Value)
     ) %>%
-    dplyr::arrange(match(Variable, vars_str))
+    dplyr::arrange(match(.data$Variable, vars_str))
 
 }
 
@@ -104,15 +104,15 @@ describe_cat <- function(data, ...) {
   data %>%
     dplyr::select(!!!vars, !!!grouping) %>%
     tidyr::pivot_longer(c(!!!vars), names_to = "Variable", values_to = "Value") %>%
-    dplyr::group_by(Variable, .add = TRUE, .drop = TRUE) %>%
+    dplyr::group_by(.data$Variable, .add = TRUE, .drop = TRUE) %>%
     dplyr::summarise(
-      N = dplyr::n() - sum(is.na(Value)),
-      Missing = sum(is.na(Value)),
-      Unique = length(unique(Value)),
-      Mode = as.character(get_mode(Value)),
-      Mode_N = sum(Value == Mode, na.rm = TRUE)
+      N = dplyr::n() - sum(is.na(.data$Value)),
+      Missing = sum(is.na(.data$Value)),
+      Unique = length(unique(.data$Value)),
+      Mode = as.character(get_mode(.data$Value)),
+      Mode_N = sum(.data$Value == .data$Mode, na.rm = TRUE)
     ) %>%
-    dplyr::arrange(match(Variable, vars_str))
+    dplyr::arrange(match(.data$Variable, vars_str))
 }
 
 ### Internal functions ###

--- a/R/unianova.R
+++ b/R/unianova.R
@@ -90,15 +90,15 @@ compute_aov <- function(test_var, data, group_var, descriptives, post_hoc) {
       dplyr::group_by({{ group_var }}) %>%
       dplyr::summarise(M = mean({{ test_var }}, na.rm = TRUE),
                        SD = sd({{ test_var }}, na.rm = TRUE)) %>%
-      tidyr::gather("stat", "val", M, SD)
+      tidyr::gather("stat", "val", .data$M, .data$SD)
 
     desc_df <- desc_df %>%
       dplyr::group_by({{ group_var }}) %>%
       dplyr::mutate(order_var = dplyr::cur_group_id()) %>%
       dplyr::ungroup() %>%
-      tidyr::unite("name", order_var, stat, {{ group_var }}) %>%
-      dplyr::mutate(name = stringr::str_replace_all(name, " ", "_")) %>%
-      tidyr::spread(name, val) %>%
+      tidyr::unite("name", .data$order_var, .data$stat, {{ group_var }}) %>%
+      dplyr::mutate(name = stringr::str_replace_all(.data$name, " ", "_")) %>%
+      tidyr::spread(.data$name, .data$val) %>%
       dplyr::rename_all(stringr::str_replace, "\\d*_", "")
 
     aov_df <- aov_df %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,7 +36,7 @@ grab_vars <- function(data, vars, alternative = "numeric", exclude_vars = NULL) 
     if (alternative == "all") {
       vars <- data %>%
         dplyr::ungroup() %>%
-        dplyr::select(-tidyselect::all_of(exclude_vars)) %>%
+        dplyr::select(-exclude_vars) %>%
         names() %>%
         syms()
     }
@@ -47,7 +47,7 @@ grab_vars <- function(data, vars, alternative = "numeric", exclude_vars = NULL) 
   } else {
     vars <- data %>%
       dplyr::ungroup() %>%
-      dplyr::select(!!!vars, -tidyselect::all_of(exclude_vars)) %>%
+      dplyr::select(!!!vars, -exclude_vars) %>%
       names() %>%
       syms()
   }


### PR DESCRIPTION
Reverts joon-e/tidycomm#19

I'm reverting this, as it might have been a bit rash - turns out, use of `.data` is only deprecated in [_some_ situations](https://github.com/r-lib/tidyselect/issues/169). Not sure why this didn't throw any notes whilst checking on my Windows computer, but I'm getting new notes now on MacOS. Will be adding a fix soon.