### PR TITLE
R cmd check fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,4 +52,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3

--- a/R/categorical.R
+++ b/R/categorical.R
@@ -28,11 +28,11 @@ tab_frequencies <- function(data, ...) {
   d %>%
     dplyr::bind_cols(d %>%
                 dplyr::select(!!!grouping,
-                       cum_n = .data$n,
-                       cum_percent = .data$percent) %>%
+                       cum_n = "n",
+                       cum_percent = "percent") %>%
                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), cumsum) %>%
                 dplyr::ungroup() %>%
-                dplyr::select(.data$cum_n, .data$cum_percent)
+                dplyr::select("cum_n", "cum_percent")
     )
 
 }
@@ -82,10 +82,10 @@ crosstab <- function(data, col_var, ..., add_total = FALSE,
     dplyr::ungroup()
 
   xt_cross_vars <- xt %>%
-    dplyr::select(c(1:cross_vars))
+    dplyr::select(1:tidyselect::all_of(cross_vars))
 
   xt_col_vars <- xt %>%
-    dplyr::select(-c(1:cross_vars))
+    dplyr::select(-(1:tidyselect::all_of(cross_vars)))
 
   if (chi_square) {
     chi2 <- xt_col_vars %>%
@@ -95,7 +95,8 @@ crosstab <- function(data, col_var, ..., add_total = FALSE,
     test_string <- "Chi-square = %f, df = %f, p = %f, V = %f"
 
     message(sprintf(test_string,
-                    chi2$statistic, chi2$parameter, chi2$p.value, cramer_V(chi2)))
+                    chi2$statistic, chi2$parameter, chi2$p.value,
+                    cramer_V(chi2)))
   }
 
   if (add_total) {

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -63,12 +63,13 @@ to_correlation_matrix <- function(data) {
     dplyr::bind_rows(
       data %>%
         dplyr::select(x = 1, y = 2, cor = 3) %>%
-        dplyr::rename(x = .data$y, y = .data$x)
+        dplyr::rename(x = "y", y = "x")
     ) %>%
     tidyr::spread(.data$y, .data$cor, fill = 1) %>%
     dplyr::arrange(match(.data$x, var_order)) %>%
-    dplyr::rename(!!estimate := .data$x) %>%
-    dplyr::select(estimate, var_order, dplyr::everything())
+    dplyr::rename(!!estimate := "x") %>%
+    dplyr::select(tidyselect::all_of(estimate), tidyselect::all_of(var_order),
+                  dplyr::everything())
 }
 
 ### Internal functions ###

--- a/R/unianova.R
+++ b/R/unianova.R
@@ -90,13 +90,13 @@ compute_aov <- function(test_var, data, group_var, descriptives, post_hoc) {
       dplyr::group_by({{ group_var }}) %>%
       dplyr::summarise(M = mean({{ test_var }}, na.rm = TRUE),
                        SD = sd({{ test_var }}, na.rm = TRUE)) %>%
-      tidyr::gather("stat", "val", .data$M, .data$SD)
+      tidyr::gather("stat", "val", "M", "SD")
 
     desc_df <- desc_df %>%
       dplyr::group_by({{ group_var }}) %>%
       dplyr::mutate(order_var = dplyr::cur_group_id()) %>%
       dplyr::ungroup() %>%
-      tidyr::unite("name", .data$order_var, .data$stat, {{ group_var }}) %>%
+      tidyr::unite("name", "order_var", "stat", {{ group_var }}) %>%
       dplyr::mutate(name = stringr::str_replace_all(.data$name, " ", "_")) %>%
       tidyr::spread(.data$name, .data$val) %>%
       dplyr::rename_all(stringr::str_replace, "\\d*_", "")

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,7 +13,8 @@
 ## @return Variables as symbols
 ##
 ## @keywords internal
-grab_vars <- function(data, vars, alternative = "numeric", exclude_vars = NULL) {
+grab_vars <- function(data, vars, alternative = "numeric",
+                      exclude_vars = NULL) {
   if (length(vars) == 0) {
     if (alternative == "numeric") {
       vars <- data %>%
@@ -36,7 +37,7 @@ grab_vars <- function(data, vars, alternative = "numeric", exclude_vars = NULL) 
     if (alternative == "all") {
       vars <- data %>%
         dplyr::ungroup() %>%
-        dplyr::select(-exclude_vars) %>%
+        dplyr::select(-tidyselect::all_of(exclude_vars)) %>%
         names() %>%
         syms()
     }
@@ -47,7 +48,7 @@ grab_vars <- function(data, vars, alternative = "numeric", exclude_vars = NULL) 
   } else {
     vars <- data %>%
       dplyr::ungroup() %>%
-      dplyr::select(!!!vars, -exclude_vars) %>%
+      dplyr::select(!!!vars, -tidyselect::all_of(exclude_vars)) %>%
       names() %>%
       syms()
   }


### PR DESCRIPTION
Sorry for the confusion, but I had to revert #20 due to some misunderstanding. This should fix the R CMD Check notes on all platforms. I have also added a requirement for the newest Roxygen2 version (7.2.3) in the `DESCRIPTION` -- a mismatch between installed and documented version doesn't result in a note, but still some red font in the check output.

Also, check "Hide whitespace" in the diff viewer, unfortunately I converted some line endings.