### PR TITLE
updated cran-comments to report all checks and remaining notes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycomm
 Title: Data Modification and Analysis for Communication Research
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
     person("Julian", "Unkel", , "julian.unkel@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9568-7041")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tidycomm 0.4.0
+# tidycomm 0.4.1
 
 # tidycomm 0.3.0
 

--- a/R/data.R
+++ b/R/data.R
@@ -1,6 +1,6 @@
 #' Worlds of Journalism sample data
 #'
-#' A subset of data from the [Worlds of Journalism](https://www.worldsofjournalism.org/)
+#' A subset of data from the [Worlds of Journalism](https://worldsofjournalism.org/)
 #' 2012-16 study containing survey data of 1,200 journalists from five European
 #' countries.
 #'
@@ -38,7 +38,7 @@
 #'   \item{trust_politicians}{Trust placed in politicians in general,
 #'     scale from 1 (*no trust at all*) to 5 (*complete trust*)}
 #' }
-#' @source \url{https://worldsofjournalism.org/data/data-and-key-tables-2012-2016}
+#' @source \samp{https://worldsofjournalism.org/data/data-and-key-tables-2012-2016}
 "WoJ"
 
 #' Facebook posts reliability test
@@ -84,7 +84,7 @@
 #' Kümpel, A. S., & Unkel, J. (2020). Negativity wins at last: How presentation
 #' order and valence of user comments affect perceptions of journalistic quality.
 #' Journal of Media Psychology: Theories, Methods, and Applications, 32(2), 89–99.
-#' \url{https://doi.org/10.1027/1864-1105/a000261}
+#' \doi{10.1027/1864-1105/a000261}
 #'
 #' @format A data frame of 630 observations and 15 variables:
 #' \describe{

--- a/R/scaling.R
+++ b/R/scaling.R
@@ -646,7 +646,7 @@ recode_cat_scale <- function(data, ..., assign = NULL,
 #' variables based on a specified lower end, upper end, and intermediate breaks.
 #' The intervals created include the right endpoint of the interval. For example,
 #' breaks = c(2, 3) with lower_end = 1 and upper_end = 5 creates intervals from
-#' 1 to ≤ 2, >2 to ≤ 3, and >3 to ≤ 5. If the lower or upper ends are not provided,
+#' 1 to <= 2, >2 to <= 3, and >3 to <= 5. If the lower or upper ends are not provided,
 #' the function defaults to the minimum and maximum values of the data and issues
 #' a warning. This default behavior is prone to errors, however, because a scale may not
 #' include its actual lower and upper ends which might in turn affect the recoding

--- a/R/tdcmm_class.R
+++ b/R/tdcmm_class.R
@@ -194,6 +194,7 @@ model.tdcmm <- function(x, ...) {
 #' @family visualize
 #'
 #' @examples
+#' \dontrun{
 #' WoJ %>%
 #'   describe() %>%
 #'   visualize()
@@ -212,6 +213,7 @@ model.tdcmm <- function(x, ...) {
 #' WoJ %>%
 #'   crosstab(reach, employment) %>%
 #'   visualize()
+#'
 #' fbposts %>%
 #'   crosstab(coder_id, type, percentages = TRUE) %>%
 #'   visualize()
@@ -260,6 +262,7 @@ model.tdcmm <- function(x, ...) {
 #'   describe_cat() %>%
 #'   visualize() +
 #'     ggplot2::scale_fill_grey()
+#'}
 #'
 #' @export
 visualize <- function(x, ..., .design = design_lmu()) {

--- a/R/unianova.R
+++ b/R/unianova.R
@@ -23,8 +23,10 @@
 #'
 #' @examples
 #' WoJ %>% unianova(employment, autonomy_selection, autonomy_emphasis)
-#' WoJ %>% unianova(employment)
 #' WoJ %>% unianova(employment, descriptives = TRUE, post_hoc = TRUE)
+#' \dontrun{
+#' WoJ %>% unianova(employment)
+#' }
 #'
 #' @export
 unianova <- function(data, group_var, ..., descriptives = FALSE, post_hoc = FALSE) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,7 +131,7 @@ format_value <- function(x, d) trimws(format(round(x, d), nsmall = d))
 
 #' Helper function for labelling purposes
 #'
-#' @param numeric share between 0 and 1
+#' @param x share between 0 and 1
 #'
 #' @return a string with formatted % (rounded and suffixed)
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-This update raises version to 0.4.0  since it introduces new tdcmm/tibble returns and new functions, such as partial correlation, linear regression, one-sample t-test, scale transformations, percentiles, visualizations, and additional datasets (snscomments and incvlcomments).
+This update elevates the version directly to 0.4.1 as it introduces significant enhancements including new tdcmm/tibble returns and functions such as partial correlation, linear regression, one-sample t-test, scale transformations, percentiles, visualizations, and additional datasets (snscomments and incvlcomments). Additionally, we have applied a minor patch to encase the 'visualize()' examples within 'dontrun()' to reduce the elapsed time during the compilation of these examples.
 
 ## Test environments
 
@@ -8,6 +8,28 @@ This update raises version to 0.4.0  since it introduces new tdcmm/tibble return
 * Ubuntu 20.04 (on GitHub Actions), devel
 * Windows latest (on GitHub Actions), release
 
+There were 3 NOTES identified when testing the package on Windows using R-hub, but all are referenced in the open issues of the R-hub package and thus appear to be unrelated to this package:
+
+> checking for non-standard things in the check directory ... NOTE
+Found the following files/directories:
+  ''NULL''
+
+> checking for detritus in the temp directory ... NOTE
+Found the following files/directories:
+  'lastMiKTeXException'
+
+> checking HTML version of manual ... NOTE
+   Skipping checking math rendering: package 'V8' unavailable
+
+
 ## R CMD check results
 
 0 errors | 0 warnings | 0 note
+
+
+## revdepcheck results
+
+We checked 0 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages

--- a/man/WoJ.Rd
+++ b/man/WoJ.Rd
@@ -41,7 +41,7 @@ scale from 1 (\emph{no trust at all}) to 5 (\emph{complete trust})}
 }
 }
 \source{
-\url{https://worldsofjournalism.org/data-d79/data-and-key-tables-2012-2016/}
+\samp{https://worldsofjournalism.org/data/data-and-key-tables-2012-2016}
 }
 \usage{
 WoJ

--- a/man/categorize_scale.Rd
+++ b/man/categorize_scale.Rd
@@ -52,7 +52,7 @@ This function recodes one or more numeric variables into categorical
 variables based on a specified lower end, upper end, and intermediate breaks.
 The intervals created include the right endpoint of the interval. For example,
 breaks = c(2, 3) with lower_end = 1 and upper_end = 5 creates intervals from
-1 to ≤ 2, >2 to ≤ 3, and >3 to ≤ 5. If the lower or upper ends are not provided,
+1 to <= 2, >2 to <= 3, and >3 to <= 5. If the lower or upper ends are not provided,
 the function defaults to the minimum and maximum values of the data and issues
 a warning. This default behavior is prone to errors, however, because a scale may not
 include its actual lower and upper ends which might in turn affect the recoding

--- a/man/percentage_labeller.Rd
+++ b/man/percentage_labeller.Rd
@@ -7,7 +7,7 @@
 percentage_labeller(x)
 }
 \arguments{
-\item{numeric}{share between 0 and 1}
+\item{x}{share between 0 and 1}
 }
 \value{
 a string with formatted \% (rounded and suffixed)

--- a/man/snscomments.Rd
+++ b/man/snscomments.Rd
@@ -44,6 +44,6 @@ corresponding to the paper:
 Kümpel, A. S., & Unkel, J. (2020). Negativity wins at last: How presentation
 order and valence of user comments affect perceptions of journalistic quality.
 Journal of Media Psychology: Theories, Methods, and Applications, 32(2), 89–99.
-\url{https://doi.org/10.1027/1864-1105/a000261}
+\doi{10.1027/1864-1105/a000261}
 }
 \keyword{datasets}

--- a/man/unianova.Rd
+++ b/man/unianova.Rd
@@ -34,8 +34,10 @@ Otherwise Welch's ANOVA with a (Satterthwaite's) approximation to the degrees of
 }
 \examples{
 WoJ \%>\% unianova(employment, autonomy_selection, autonomy_emphasis)
-WoJ \%>\% unianova(employment)
 WoJ \%>\% unianova(employment, descriptives = TRUE, post_hoc = TRUE)
+\dontrun{
+WoJ \%>\% unianova(employment)
+}
 
 }
 \concept{ANOVA}

--- a/man/visualize.Rd
+++ b/man/visualize.Rd
@@ -137,6 +137,7 @@ or overwriting individual geom's or scale's. See the examples below and the
 documentation of \link{ggplot2}.
 }
 \examples{
+\dontrun{
 WoJ \%>\%
   describe() \%>\%
   visualize()
@@ -155,6 +156,7 @@ fbposts \%>\%
 WoJ \%>\%
   crosstab(reach, employment) \%>\%
   visualize()
+
 fbposts \%>\%
   crosstab(coder_id, type, percentages = TRUE) \%>\%
   visualize()
@@ -203,6 +205,7 @@ fbposts \%>\%
   describe_cat() \%>\%
   visualize() +
     ggplot2::scale_fill_grey()
+}
 
 }
 \concept{visualize}

--- a/revdep/.gitignore
+++ b/revdep/.gitignore
@@ -4,3 +4,4 @@ checks.noindex
 library.noindex
 data.sqlite
 *.html
+cloud.noindex

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,75 +1,135 @@
 # Platform
 
-|field    |value                        |
-|:--------|:----------------------------|
-|version  |R version 3.6.1 (2019-07-05) |
-|os       |Windows 10 x64               |
-|system   |x86_64, mingw32              |
-|ui       |RStudio                      |
-|language |(EN)                         |
-|collate  |English_United States.1252   |
-|ctype    |English_United States.1252   |
-|tz       |Europe/Berlin                |
-|date     |2019-09-21                   |
+|field    |value                                                                                |
+|:--------|:------------------------------------------------------------------------------------|
+|version  |R version 4.3.2 (2023-10-31 ucrt)                                                    |
+|os       |Windows 11 x64 (build 22631)                                                         |
+|system   |x86_64, mingw32                                                                      |
+|ui       |RStudio                                                                              |
+|language |(EN)                                                                                 |
+|collate  |German_Germany.utf8                                                                  |
+|ctype    |German_Germany.utf8                                                                  |
+|tz       |Europe/Berlin                                                                        |
+|date     |2024-02-21                                                                           |
+|rstudio  |2023.06.1+524 Mountain Hydrangea (desktop)                                           |
+|pandoc   |3.1.1 @ C:/Program Files/RStudio/resources/app/bin/quarto/bin/tools/ (via rmarkdown) |
 
 # Dependencies
 
-|package     |old        |new        |<U+0394>  |
-|:-----------|:----------|:----------|:--|
-|tidycomm    |0.0.1      |0.1.0      |*  |
-|abind       |1.4-5      |1.4-5      |   |
-|arm         |1.10-1     |1.10-1     |   |
-|assertthat  |0.2.1      |0.2.1      |   |
-|backports   |1.1.4      |1.1.4      |   |
-|BH          |1.69.0-1   |1.69.0-1   |   |
-|broom       |0.5.2      |0.5.2      |   |
-|cli         |1.1.0      |1.1.0      |   |
-|coda        |0.19-3     |0.19-3     |   |
-|crayon      |1.3.4      |1.3.4      |   |
-|digest      |0.6.21     |0.6.21     |   |
-|dplyr       |0.8.3      |0.8.3      |   |
-|ellipsis    |0.3.0      |0.3.0      |   |
-|fansi       |0.4.0      |0.4.0      |   |
-|forcats     |0.4.0      |0.4.0      |   |
-|generics    |0.0.2      |0.0.2      |   |
-|glue        |1.3.1      |1.3.1      |   |
-|gsl         |2.1-6      |2.1-6      |   |
-|lavaan      |0.6-5      |0.6-5      |   |
-|lifecycle   |0.1.0      |0.1.0      |   |
-|lme4        |1.1-21     |1.1-21     |   |
-|magrittr    |1.5        |1.5        |   |
-|matrixcalc  |1.0-3      |1.0-3      |   |
-|MBESS       |4.6.0      |4.6.0      |   |
-|mi          |1.0        |1.0        |   |
-|minqa       |1.2.4      |1.2.4      |   |
-|mnormt      |1.5-5      |1.5-5      |   |
-|mvtnorm     |1.0-11     |1.0-11     |   |
-|nloptr      |1.2.1      |1.2.1      |   |
-|numDeriv    |2016.8-1.1 |2016.8-1.1 |   |
-|OpenMx      |2.13.2     |2.13.2     |   |
-|pbivnorm    |0.6.0      |0.6.0      |   |
-|pillar      |1.4.2      |1.4.2      |   |
-|pkgconfig   |2.0.2      |2.0.2      |   |
-|plogr       |0.2.0      |0.2.0      |   |
-|plyr        |1.8.4      |1.8.4      |   |
-|purrr       |0.3.2      |0.3.2      |   |
-|R6          |2.4.0      |2.4.0      |   |
-|Rcpp        |1.0.2      |1.0.2      |   |
-|RcppEigen   |0.3.3.5.0  |0.3.3.5.0  |   |
-|reshape2    |1.4.3      |1.4.3      |   |
-|rlang       |0.4.0      |0.4.0      |   |
-|rpf         |0.62       |0.62       |   |
-|sem         |3.1-9      |3.1-9      |   |
-|semTools    |0.5-2      |0.5-2      |   |
-|StanHeaders |2.19.0     |2.19.0     |   |
-|stringi     |1.4.3      |1.4.3      |   |
-|stringr     |1.4.0      |1.4.0      |   |
-|tibble      |2.1.3      |2.1.3      |   |
-|tidyr       |1.0.0      |1.0.0      |   |
-|tidyselect  |0.2.5      |0.2.5      |   |
-|utf8        |1.1.4      |1.1.4      |   |
-|vctrs       |0.2.0      |0.2.0      |   |
-|zeallot     |0.1.0      |0.1.0      |   |
+|package       |old        |new        |Δ  |
+|:-------------|:----------|:----------|:--|
+|tidycomm      |0.2.1      |0.4.1      |*  |
+|abind         |1.4-5      |1.4-5      |   |
+|arm           |1.13-1     |1.13-1     |   |
+|backports     |1.4.1      |1.4.1      |   |
+|BH            |1.84.0-0   |1.84.0-0   |   |
+|bit           |NA         |4.0.5      |*  |
+|bit64         |NA         |4.0.5      |*  |
+|brio          |1.1.4      |1.1.4      |   |
+|broom         |1.0.5      |1.0.5      |   |
+|broom.helpers |NA         |1.14.0     |*  |
+|callr         |3.7.5      |3.7.5      |   |
+|car           |NA         |3.1-2      |*  |
+|carData       |NA         |3.0-5      |*  |
+|cellranger    |NA         |1.1.0      |*  |
+|cli           |3.6.2      |3.6.2      |   |
+|clipr         |NA         |0.8.0      |*  |
+|coda          |0.19-4.1   |0.19-4.1   |   |
+|colorspace    |NA         |2.1-0      |*  |
+|cpp11         |0.4.7      |0.4.7      |   |
+|crayon        |1.5.2      |1.5.2      |   |
+|data.table    |NA         |1.15.0     |*  |
+|desc          |1.4.3      |1.4.3      |   |
+|diffobj       |0.3.5      |0.3.5      |   |
+|digest        |0.6.34     |0.6.34     |   |
+|dplyr         |1.1.4      |1.1.4      |   |
+|ellipsis      |0.3.2      |0.3.2      |   |
+|evaluate      |0.23       |0.23       |   |
+|fansi         |1.0.6      |1.0.6      |   |
+|farver        |NA         |2.1.1      |*  |
+|fastDummies   |NA         |1.7.3      |*  |
+|forcats       |1.0.0      |1.0.0      |   |
+|fs            |1.6.3      |1.6.3      |   |
+|generics      |0.1.3      |0.1.3      |   |
+|GGally        |NA         |2.2.1      |*  |
+|ggplot2       |NA         |3.4.4      |*  |
+|ggstats       |NA         |0.5.1      |*  |
+|glue          |1.7.0      |1.7.0      |   |
+|gtable        |NA         |0.3.4      |*  |
+|haven         |NA         |2.5.4      |*  |
+|hms           |NA         |1.1.3      |*  |
+|isoband       |NA         |0.2.7      |*  |
+|jsonlite      |1.8.8      |1.8.8      |   |
+|labeling      |NA         |0.4.3      |*  |
+|labelled      |NA         |2.12.0     |*  |
+|lavaan        |0.6-17     |0.6-17     |   |
+|lifecycle     |1.0.4      |1.0.4      |   |
+|lm.beta       |NA         |1.7-2      |*  |
+|lme4          |1.1-35.1   |1.1-35.1   |   |
+|lubridate     |NA         |1.9.3      |*  |
+|magrittr      |2.0.3      |2.0.3      |   |
+|MatrixModels  |NA         |0.5-3      |*  |
+|MBESS         |4.9.3      |4.9.3      |   |
+|mi            |1.1        |1.1        |   |
+|minqa         |1.2.6      |1.2.6      |   |
+|misty         |NA         |0.6.2      |*  |
+|mnormt        |2.1.1      |2.1.1      |   |
+|munsell       |NA         |0.5.0      |*  |
+|mvtnorm       |1.2-4      |1.2-4      |   |
+|nloptr        |2.0.3      |2.0.3      |   |
+|norm          |NA         |1.0-11.1   |*  |
+|numDeriv      |2016.8-1.1 |2016.8-1.1 |   |
+|OpenMx        |2.21.11    |2.21.11    |   |
+|patchwork     |NA         |1.2.0      |*  |
+|pbivnorm      |0.6.0      |0.6.0      |   |
+|pbkrtest      |NA         |0.5.2      |*  |
+|pillar        |1.9.0      |1.9.0      |   |
+|pkgbuild      |1.4.3      |1.4.3      |   |
+|pkgconfig     |2.0.3      |2.0.3      |   |
+|pkgload       |1.3.4      |1.3.4      |   |
+|plyr          |NA         |1.8.9      |*  |
+|praise        |1.0.0      |1.0.0      |   |
+|prettyunits   |NA         |1.2.0      |*  |
+|processx      |3.8.3      |3.8.3      |   |
+|progress      |NA         |1.2.3      |*  |
+|ps            |1.7.6      |1.7.6      |   |
+|purrr         |1.0.2      |1.0.2      |   |
+|quadprog      |1.5-8      |1.5-8      |   |
+|quantreg      |NA         |5.97       |*  |
+|R6            |2.5.1      |2.5.1      |   |
+|RColorBrewer  |NA         |1.1-3      |*  |
+|Rcpp          |1.0.12     |1.0.12     |   |
+|RcppEigen     |0.3.3.9.4  |0.3.3.9.4  |   |
+|RcppParallel  |5.1.7      |5.1.7      |   |
+|readr         |NA         |2.1.5      |*  |
+|readxl        |NA         |1.4.3      |*  |
+|rematch       |NA         |2.0.0      |*  |
+|rematch2      |2.1.2      |2.1.2      |   |
+|rlang         |1.1.3      |1.1.3      |   |
+|rpf           |1.0.14     |1.0.14     |   |
+|rprojroot     |2.0.4      |2.0.4      |   |
+|rstudioapi    |NA         |0.15.0     |*  |
+|scales        |NA         |1.3.0      |*  |
+|sem           |3.1-15     |3.1-15     |   |
+|semTools      |0.5-6      |0.5-6      |   |
+|SparseM       |NA         |1.81       |*  |
+|StanHeaders   |2.32.5     |2.32.5     |   |
+|stringi       |1.8.3      |1.8.3      |   |
+|stringr       |1.5.1      |1.5.1      |   |
+|testthat      |3.2.1      |3.2.1      |   |
+|tibble        |3.2.1      |3.2.1      |   |
+|tidyr         |1.3.1      |1.3.1      |   |
+|tidyselect    |1.2.0      |1.2.0      |   |
+|timechange    |NA         |0.3.0      |*  |
+|tzdb          |NA         |0.4.0      |*  |
+|utf8          |1.2.4      |1.2.4      |   |
+|vctrs         |0.6.5      |0.6.5      |   |
+|viridisLite   |NA         |0.4.2      |*  |
+|vroom         |NA         |1.6.5      |*  |
+|waldo         |0.5.2      |0.5.2      |   |
+|withr         |3.0.0      |3.0.0      |   |
+|writexl       |NA         |1.5.0      |*  |
+|xtable        |NA         |1.8-4      |*  |
 
 # Revdeps
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,0 +1,7 @@
+## revdepcheck results
+
+We checked 0 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages
+


### PR DESCRIPTION
This final PR incorporates the most recent updates to meet CRAN checks, including:

- Explaining the raised version number (v0.4.1) in `cran-comments.md`
- Addressing remaining NOTES from `rhub::check_for_cran()` in `cran-comments.md`
- Reporting results from `revdepcheck` in `cran-comments.md`
- Implementing some very minor changes in .R files (e.g., avoiding certain Unicode characters, fixing broken URLs) to meet CRAN checks
- Adding `dontrun{}` to `visualize()` examples and one `unianova()` example to reduce elapsed time during CRAN checks
- Raising the version number to v0.4.1 to indicate these minor patches

--> After merging the PR into the master branch, we can proceed to `devtools::submit_cran()`